### PR TITLE
Add SKU field to sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ externalities like carbon footprint or resource depletion.
 
 ## Usage
 
-1. Prepare a JSON file describing your products. A sample file named
-   `sample_data.json` is included:
+1. Prepare a JSON file describing your products. Each entry should include a
+   unique `sku` identifier. A sample file named `sample_data.json` is included:
 
 ```json
 [
   {
+    "sku": "WID-001",
     "name": "Widget",
     "price": 10.0,
     "externalities": {

--- a/pantopia/cli.py
+++ b/pantopia/cli.py
@@ -15,7 +15,11 @@ def main():
     for item in data:
         ext = Externalities(**item["externalities"])
         rc = real_cost(item["price"], ext)
-        print(f"{item['name']}: ${rc:.2f} (base ${item['price']:.2f})")
+        sku = item.get("sku", item.get("id", ""))
+        if sku:
+            print(f"{sku} {item['name']}: ${rc:.2f} (base ${item['price']:.2f})")
+        else:
+            print(f"{item['name']}: ${rc:.2f} (base ${item['price']:.2f})")
 
 if __name__ == "__main__":
     main()

--- a/sample_data.json
+++ b/sample_data.json
@@ -1,5 +1,6 @@
 [
   {
+    "sku": "WID-001",
     "name": "Widget",
     "price": 10.0,
     "externalities": {
@@ -10,6 +11,7 @@
     }
   },
   {
+    "sku": "GAD-001",
     "name": "Gadget",
     "price": 15.0,
     "externalities": {
@@ -20,6 +22,7 @@
     }
   },
   {
+    "sku": "THG-001",
     "name": "Thingamajig",
     "price": 20.0,
     "externalities": {


### PR DESCRIPTION
## Summary
- include unique `sku` field in sample data
- mention SKU identifier in README example
- output SKU in CLI results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684328e63a2c8327b8c8226071bff0a5