### PR TITLE
Add SKU filter option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ externalities like carbon footprint or resource depletion.
 python -m pantopia.cli sample_data.json
 ```
 
+You can also display the cost for a single SKU:
+
+```bash
+python -m pantopia.cli sample_data.json --sku WID-001
+```
+
 ## Testing
 
 Run the unit tests with:

--- a/pantopia/cli.py
+++ b/pantopia/cli.py
@@ -1,5 +1,6 @@
 import json
 import argparse
+import sys
 from .real_cost import Externalities, real_cost
 
 def load_data(path: str):
@@ -9,9 +10,16 @@ def load_data(path: str):
 def main():
     parser = argparse.ArgumentParser(description="Calculate real cost of products")
     parser.add_argument("data", help="JSON file with product data")
+    parser.add_argument("--sku", help="Display only the product with this SKU")
     args = parser.parse_args()
 
     data = load_data(args.data)
+    if args.sku:
+        data = [item for item in data if item.get("sku") == args.sku]
+        if not data:
+            print(f"SKU {args.sku} not found", file=sys.stderr)
+            return
+
     for item in data:
         ext = Externalities(**item["externalities"])
         rc = real_cost(item["price"], ext)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_filter_sku():
+    data_path = Path(__file__).resolve().parent.parent / "sample_data.json"
+    result = subprocess.run([
+        sys.executable,
+        "-m",
+        "pantopia.cli",
+        str(data_path),
+        "--sku",
+        "WID-001",
+    ], capture_output=True, text=True)
+    assert "WID-001" in result.stdout
+    assert "Widget" in result.stdout
+    assert "$12.00" in result.stdout
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add `--sku` option to CLI to filter output by product
- update README with usage info for filtering
- test CLI SKU filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a9715e08327a42f83eb869cc508