### PR TITLE
Add global SKU support and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ externalities like carbon footprint or resource depletion.
 ## Usage
 
 1. Prepare a JSON file describing your products. Each entry should include a
-   unique `sku` identifier. A sample file named `sample_data.json` is included:
+   globally unique `sku` along with a short `description` and `origin` field.
+   A sample file named `sample_data.json` is included:
 
 ```json
 [
   {
-    "sku": "WID-001",
+    "sku": "11111111-1111-1111-1111-111111111111",
     "name": "Widget",
+    "description": "A standard widget",
+    "origin": "USA",
     "price": 10.0,
     "externalities": {
       "carbon": 1.0,
@@ -34,7 +37,7 @@ python -m pantopia.cli sample_data.json
 You can also display the cost for a single SKU:
 
 ```bash
-python -m pantopia.cli sample_data.json --sku WID-001
+python -m pantopia.cli sample_data.json --sku 11111111-1111-1111-1111-111111111111
 ```
 
 ## Testing

--- a/pantopia/cli.py
+++ b/pantopia/cli.py
@@ -1,11 +1,14 @@
 import json
 import argparse
 import sys
-from .real_cost import Externalities, real_cost
+from .real_cost import real_cost
+from .product import Product
 
 def load_data(path: str):
+    """Load product data from JSON and return a list of ``Product`` objects."""
     with open(path) as f:
-        return json.load(f)
+        raw = json.load(f)
+    return [Product.from_dict(item) for item in raw]
 
 def main():
     parser = argparse.ArgumentParser(description="Calculate real cost of products")
@@ -15,19 +18,14 @@ def main():
 
     data = load_data(args.data)
     if args.sku:
-        data = [item for item in data if item.get("sku") == args.sku]
+        data = [item for item in data if item.sku == args.sku]
         if not data:
             print(f"SKU {args.sku} not found", file=sys.stderr)
             return
 
     for item in data:
-        ext = Externalities(**item["externalities"])
-        rc = real_cost(item["price"], ext)
-        sku = item.get("sku", item.get("id", ""))
-        if sku:
-            print(f"{sku} {item['name']}: ${rc:.2f} (base ${item['price']:.2f})")
-        else:
-            print(f"{item['name']}: ${rc:.2f} (base ${item['price']:.2f})")
+        rc = real_cost(item.price, item.externalities)
+        print(f"{item.sku} {item.name}: ${rc:.2f} (base ${item.price:.2f})")
 
 if __name__ == "__main__":
     main()

--- a/pantopia/product.py
+++ b/pantopia/product.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+from .real_cost import Externalities
+
+@dataclass
+class Product:
+    """Representation of a product with global SKU."""
+
+    name: str
+    price: float
+    externalities: Externalities
+    description: str = ""
+    origin: str = ""
+    sku: str = field(default_factory=lambda: str(uuid4()))
+
+    @staticmethod
+    def from_dict(data: dict) -> "Product":
+        sku = data.get("sku") or str(uuid4())
+        ext_data = data.get("externalities", {})
+        ext = Externalities(**ext_data)
+        return Product(
+            name=data.get("name", ""),
+            price=data.get("price", 0.0),
+            externalities=ext,
+            description=data.get("description", ""),
+            origin=data.get("origin", ""),
+            sku=sku,
+        )

--- a/sample_data.json
+++ b/sample_data.json
@@ -1,7 +1,9 @@
 [
   {
-    "sku": "WID-001",
+    "sku": "11111111-1111-1111-1111-111111111111",
     "name": "Widget",
+    "description": "A standard widget",
+    "origin": "USA",
     "price": 10.0,
     "externalities": {
       "carbon": 1.0,
@@ -11,8 +13,10 @@
     }
   },
   {
-    "sku": "GAD-001",
+    "sku": "22222222-2222-2222-2222-222222222222",
     "name": "Gadget",
+    "description": "A useful gadget",
+    "origin": "Canada",
     "price": 15.0,
     "externalities": {
       "carbon": 2.0,
@@ -22,8 +26,10 @@
     }
   },
   {
-    "sku": "THG-001",
+    "sku": "33333333-3333-3333-3333-333333333333",
     "name": "Thingamajig",
+    "description": "An advanced thingamajig",
+    "origin": "Germany",
     "price": 20.0,
     "externalities": {
       "carbon": 1.5,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,9 +11,9 @@ def test_cli_filter_sku():
         "pantopia.cli",
         str(data_path),
         "--sku",
-        "WID-001",
+        "11111111-1111-1111-1111-111111111111",
     ], capture_output=True, text=True)
-    assert "WID-001" in result.stdout
+    assert "11111111-1111-1111-1111-111111111111" in result.stdout
     assert "Widget" in result.stdout
     assert "$12.00" in result.stdout
     assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add `Product` dataclass that generates a UUID SKU when missing
- update CLI to work with `Product` objects
- extend sample data with description and origin information
- update README example and instructions
- adjust CLI tests for new SKU values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432d151ac88327bb7840540ed66adf