### PR TITLE
Add search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ You can also display the cost for a single SKU:
 python -m pantopia.cli sample_data.json --sku 11111111-1111-1111-1111-111111111111
 ```
 
+You can search for products using a keyword (case-insensitive):
+
+```bash
+python -m pantopia.cli sample_data.json --search apple
+```
+
 ## Testing
 
 Run the unit tests with:

--- a/pantopia/cli.py
+++ b/pantopia/cli.py
@@ -14,6 +14,10 @@ def main():
     parser = argparse.ArgumentParser(description="Calculate real cost of products")
     parser.add_argument("data", help="JSON file with product data")
     parser.add_argument("--sku", help="Display only the product with this SKU")
+    parser.add_argument(
+        "--search",
+        help="Show products whose name or description contains this string",
+    )
     args = parser.parse_args()
 
     data = load_data(args.data)
@@ -21,6 +25,17 @@ def main():
         data = [item for item in data if item.sku == args.sku]
         if not data:
             print(f"SKU {args.sku} not found", file=sys.stderr)
+            return
+
+    if args.search:
+        query = args.search.lower()
+        data = [
+            item
+            for item in data
+            if query in item.name.lower() or query in item.description.lower()
+        ]
+        if not data:
+            print(f'No products found matching "{args.search}"', file=sys.stderr)
             return
 
     for item in data:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,9 +11,23 @@ def test_cli_filter_sku():
         "pantopia.cli",
         str(data_path),
         "--sku",
-        "11111111-1111-1111-1111-111111111111",
+        "a1b2c3d4-e5f6-7890-1234-567890abcdef",
     ], capture_output=True, text=True)
-    assert "11111111-1111-1111-1111-111111111111" in result.stdout
-    assert "Widget" in result.stdout
-    assert "$12.00" in result.stdout
+    assert "a1b2c3d4-e5f6-7890-1234-567890abcdef" in result.stdout
+    assert "Apple iPhone 15 Pro" in result.stdout
+    assert "$1119.78" in result.stdout
+    assert result.returncode == 0
+
+
+def test_cli_search():
+    data_path = Path(__file__).resolve().parent.parent / "sample_data.json"
+    result = subprocess.run([
+        sys.executable,
+        "-m",
+        "pantopia.cli",
+        str(data_path),
+        "--search",
+        "apple",
+    ], capture_output=True, text=True)
+    assert "Apple iPhone 15 Pro" in result.stdout
     assert result.returncode == 0


### PR DESCRIPTION
## Summary
- allow searching for products in CLI
- document search CLI option
- test SKU filtering with iPhone data
- add tests for search feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433296cda88327a48574424a43d983